### PR TITLE
Increase latest podcast episodes limit from 15 to 50

### DIFF
--- a/app/routers/podcast.py
+++ b/app/routers/podcast.py
@@ -123,7 +123,6 @@ class PodcastService:
                 if not date_str:
                     return datetime.fromtimestamp(0, UTC)
                 try:
-                    # Use fromisoformat instead of dateutil.parser.parse
                     return datetime.fromisoformat(date_str.replace("Z", "+00:00"))
                 except ValueError:
                     return datetime.fromtimestamp(0, UTC)
@@ -132,7 +131,7 @@ class PodcastService:
                 key=lambda x: parse_date(x[0].last_played_at),
                 reverse=True,
             )
-            latest_episodes = all_episodes[:15]
+            latest_episodes = all_episodes[:50]
 
             # Group episodes by podcast
             podcast_map = {}
@@ -160,7 +159,7 @@ def get_podcast_service(
 
 @router.get("/latest", response_model=List[Podcast])
 async def get_latest_episodes(service: PodcastService = Depends(get_podcast_service)):
-    """Get the 15 most recently played episodes grouped by podcast"""
+    """Get the 50 most recently played episodes grouped by podcast"""
     try:
         return await service.get_latest_episodes()
     except Exception as e:


### PR DESCRIPTION
Update PodcastService to retrieve and display the 50 most recently played podcast episodes instead of the previous 15-episode limit