### PR TITLE
Extend stats endpoint default days range to 90 days

### DIFF
--- a/app/routers/reader.py
+++ b/app/routers/reader.py
@@ -542,7 +542,7 @@ async def get_curated_later_articles(db: AsyncIOMotorDatabase = Depends(get_data
 @router.get("/stats")
 async def get_stats(
     days: int = Query(
-        default=7, ge=1, le=30, description="Number of days to look back"
+        default=90, ge=1, le=366, description="Number of days to look back"
     ),
     db: AsyncIOMotorDatabase = Depends(get_database),
 ):


### PR DESCRIPTION
Update the default days parameter in the get_stats endpoint to provide a longer historical view, increasing from 7 to 90 days while maintaining a reasonable maximum limit of 366 days